### PR TITLE
Fix error: Calling depends_on run is disabled

### DIFF
--- a/Formula/php70-mcrypt.rb
+++ b/Formula/php70-mcrypt.rb
@@ -16,7 +16,7 @@ class Php70Mcrypt < AbstractPhp70Extension
   sha256 PHP_CHECKSUM[:sha256]
 
   depends_on "mcrypt"
-  depends_on "libtool" => :run
+  depends_on "libtool" => :build
 
   def install
     Dir.chdir "ext/mcrypt"

--- a/Formula/php71-mcrypt.rb
+++ b/Formula/php71-mcrypt.rb
@@ -16,7 +16,7 @@ class Php71Mcrypt < AbstractPhp71Extension
   sha256 PHP_CHECKSUM[:sha256]
 
   depends_on "mcrypt"
-  depends_on "libtool" => :run
+  depends_on "libtool" => :build
 
   def install
     Dir.chdir "ext/mcrypt"


### PR DESCRIPTION
I decided to fix it after I saw this message in the console:

Error: Calling 'depends_on ... => :run' is disabled!
There is no replacement.
/usr/local/Homebrew/Library/Taps/kyslik/homebrew-php/Formula/php70-mcrypt.rb:19:in `<class:Php70Mcrypt>'
Please report this to the kyslik/php tap!
Or, even better, submit a PR to fix it!
If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/kyslik/homebrew-php/issues