### PR TITLE
Removed the :run dependecny from few few php extension formulas

### DIFF
--- a/Formula/php53-mcrypt.rb
+++ b/Formula/php53-mcrypt.rb
@@ -16,7 +16,7 @@ class Php53Mcrypt < AbstractPhp53Extension
   version PHP_VERSION
 
   depends_on "mcrypt"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "ext/mcrypt"

--- a/Formula/php54-mcrypt.rb
+++ b/Formula/php54-mcrypt.rb
@@ -16,7 +16,7 @@ class Php54Mcrypt < AbstractPhp54Extension
   end
 
   depends_on "mcrypt"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "ext/mcrypt"

--- a/Formula/php54-trader.rb
+++ b/Formula/php54-trader.rb
@@ -15,7 +15,7 @@ class Php54Trader < AbstractPhp54Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"

--- a/Formula/php55-mcrypt.rb
+++ b/Formula/php55-mcrypt.rb
@@ -16,7 +16,7 @@ class Php55Mcrypt < AbstractPhp55Extension
   end
 
   depends_on "mcrypt"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "ext/mcrypt"

--- a/Formula/php55-trader.rb
+++ b/Formula/php55-trader.rb
@@ -15,7 +15,7 @@ class Php55Trader < AbstractPhp55Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"

--- a/Formula/php56-trader.rb
+++ b/Formula/php56-trader.rb
@@ -15,7 +15,7 @@ class Php56Trader < AbstractPhp56Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"

--- a/Formula/php70-trader.rb
+++ b/Formula/php70-trader.rb
@@ -15,7 +15,7 @@ class Php70Trader < AbstractPhp70Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"

--- a/Formula/php71-trader.rb
+++ b/Formula/php71-trader.rb
@@ -15,7 +15,7 @@ class Php71Trader < AbstractPhp71Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"

--- a/Formula/php72-trader.rb
+++ b/Formula/php72-trader.rb
@@ -15,7 +15,7 @@ class Php72Trader < AbstractPhp72Extension
   end
 
   depends_on "ta-lib"
-  depends_on "libtool" => :run
+  #depends_on "libtool" => :run
 
   def install
     Dir.chdir "trader-#{version}"


### PR DESCRIPTION
i.e. "Calling 'depends_on ... => :run' is disabled"

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-php/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
