### PR TITLE
Remove cxx11 dependency from php70-intl

### DIFF
--- a/Formula/php70-intl.rb
+++ b/Formula/php70-intl.rb
@@ -17,8 +17,6 @@ class Php70Intl < AbstractPhp70Extension
 
   depends_on "icu4c"
 
-  needs :cxx11
-
   def install
 	# Required due to icu4c dependency
 	ENV.cxx11


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1200202/52703635-14555700-2f7f-11e9-80ef-bedcc44b889d.png)

Fixed issue where php70-intl wouldn't install anymore